### PR TITLE
Change brand color from blue to red

### DIFF
--- a/public/copyright.html
+++ b/public/copyright.html
@@ -15,7 +15,7 @@
         <div class="brand-header">TaskMaster Pro</div>
         <button class="menu-button" aria-label="Open menu">
           <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M5 20H35M5 10H35M5 30H35" stroke="#E6F0FF" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M5 20H35M5 10H35M5 30H35" class="menu-icon-lines" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
       </div>

--- a/public/feedback.html
+++ b/public/feedback.html
@@ -15,7 +15,7 @@
         <div class="brand-header">TaskMaster Pro</div>
         <button class="menu-button" aria-label="Open menu">
           <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M5 20H35M5 10H35M5 30H35" stroke="#E6F0FF" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M5 20H35M5 10H35M5 30H35" class="menu-icon-lines" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
       </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,7 +2,7 @@
 :root{
   --bg:#F9F9F9;
   --card:#FFFFFF;
-  --brand:#0066FF;
+  --brand:#FF0000;
   --borders:#CED1D4;
   --text:#000000;
   --muted:#3D4147;
@@ -13,6 +13,8 @@ html,body{height:100%;font-family:'DM Sans',-apple-system,system-ui,Segoe UI,Rob
 
 /* App root */
 .app-root{min-height:100vh;max-width:390px;margin:0 auto;position:relative;overflow-x:hidden}
+
+.menu-icon-lines{stroke:var(--brand)}
 
 /* Header: flush with top of viewport */
 .app-header{position:fixed;top:0;left:0;right:0;height:76px;background:var(--bg);z-index:1000;display:flex;align-items:center;justify-content:center;padding:12px}


### PR DESCRIPTION
## Purpose
Update the brand color scheme from blue to red as requested by the user to change the primary brand color throughout the application.

## Code changes
- Updated CSS variable `--brand` from `#0066FF` (blue) to `#FF0000` (red) in `styles.css`
- Replaced hardcoded blue stroke color `#E6F0FF` with CSS class `menu-icon-lines` in menu button SVGs across `copyright.html` and `feedback.html`
- Added new CSS rule `.menu-icon-lines{stroke:var(--brand)}` to apply the brand color to menu icons consistentlyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/537d745cd74a458f9dac077dd882d697/echo-studio)

👀 [Preview Link](https://537d745cd74a458f9dac077dd882d697-echo-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>537d745cd74a458f9dac077dd882d697</projectId>-->
<!--<branchName>echo-studio</branchName>-->