### PR TITLE
feat: Display time in hh:mm format after the date

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -20,13 +20,15 @@
   function createId(){ return Date.now().toString(36) + '-' + Math.floor(Math.random()*10000).toString(36); }
   function clamp(n, min, max){ return Math.max(min, Math.min(max, n)); }
 
-  // Format timestamp to dd/mm/yy
+  // Format timestamp to dd/mm/yy hh:mm (24h)
   function formatDate(ts){
     var d = new Date(ts);
     var dd = String(d.getDate()).padStart(2,'0');
     var mm = String(d.getMonth() + 1).padStart(2,'0');
     var yy = String(d.getFullYear()).slice(-2);
-    return dd + '/' + mm + '/' + yy;
+    var hh = String(d.getHours()).padStart(2,'0');
+    var min = String(d.getMinutes()).padStart(2,'0');
+    return dd + '/' + mm + '/' + yy + ' ' + hh + ':' + min;
   }
 
   function getTotalPages(){ return Math.max(1, Math.ceil((tasks && tasks.length ? tasks.length : 0) / pageSize)); }


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to add the time in `hh:mm` format after the date to provide more detailed timestamp information.

## Code changes

- Modified the `formatDate` function in `public/app.js`.
- The function now includes the time in `hh:mm` format in addition to the date.
- Hours and minutes are extracted from the timestamp and appended to the formatted date string.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/537d745cd74a458f9dac077dd882d697/vibe-haven)

👀 [Preview Link](https://537d745cd74a458f9dac077dd882d697-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>537d745cd74a458f9dac077dd882d697</projectId>-->
<!--<branchName>vibe-haven</branchName>-->